### PR TITLE
refactor: 'onchain' and 'offchain' to 'on-chain' and 'off-chain'

### DIFF
--- a/ERCS/erc-7571.md
+++ b/ERCS/erc-7571.md
@@ -12,15 +12,15 @@ created: 2023-11-09
 
 # Simple Summary
 
-A standard for shadow events in Ethereum smart contracts, enabling enhanced onchain data indexing, analytics, and reduced gas costs through an offchain logging mechanism.
+A standard for shadow events in Ethereum smart contracts, enabling enhanced on-chain data indexing, analytics, and reduced gas costs through an off-chain logging mechanism.
 
 This draft is a starting point for discussion and refinement. It aims to lay the foundation for a standard that could be implemented across the Ethereum ecosystem, enhancing the capabilities of smart contracts while maintaining efficiency and security.
 
 # Abstract
 
-This standard proposes a system for shadow events, which are events that are generated offchain in a shadow fork of an Ethereum compatible execution client. Shadow forks provide a mechanism to emit richer, custom, and more detailed event data without incurring the gas costs associated with onchain event logging on mainnet.
+This standard proposes a system for shadow events, which are events that are generated off-chain in a shadow fork of an Ethereum compatible execution client. Shadow forks provide a mechanism to emit richer, custom, and more detailed event data without incurring the gas costs associated with on-chain event logging on mainnet.
 
-Shadow events are emitted by shadow contracts in an offchain shadow fork environment, and would be accessible via standard JSON RPC calls. Shadow events, shadow contracts, and the types of shadow forks are described in more detail in the Specification section below.
+Shadow events are emitted by shadow contracts in an off-chain shadow fork environment, and would be accessible via standard JSON RPC calls. Shadow events, shadow contracts, and the types of shadow forks are described in more detail in the Specification section below.
 
 This standard does not intend to prescribe what event data should be logged on mainnet as opposed to a shadow fork; that decision is ultimately left to the smart contract developer.
 
@@ -28,15 +28,15 @@ This standard does not intend to prescribe what event data should be logged on m
 
 The motivation for shadow events is threefold:
 
-- **Richer Analytics**: Shadow events enable the emission of detailed data that would be prohibitively expensive to emit onchain, thus providing developers and analysts with deeper insights into contract interactions.
+- **Richer Analytics**: Shadow events enable the emission of detailed data that would be prohibitively expensive to emit on-chain, thus providing developers and analysts with deeper insights into contract interactions.
 - **Open Data Access**: Anyone can write a shadow contract implementation without affecting mainnet state, allowing the data accessibility of smart contracts to be improved upon permissionlessly.
-- **Gas Efficiency**: By allowing protocols to emit shadow events offchain, smart contracts can reduce their onchain footprint, leading to lower gas costs for users and more efficient use of blockspace.
+- **Gas Efficiency**: By allowing protocols to emit shadow events off-chain, smart contracts can reduce their on-chain footprint, leading to lower gas costs for users and more efficient use of blockspace.
 
 # Specification
 
 ## Shadow Fork
 
-A shadow fork is an offchain execution environment that mirrors Ethereum mainnet state; either in realtime or monotonically over some historical block range. Shadow forks bypass gas and contract size restrictions when executing transactions, enabling the emission of detailed event data without incurring gas costs for users on mainnet, and allowing developers to more efficiently utilize the 24,576 byte contract size limit.
+A shadow fork is an off-chain execution environment that mirrors Ethereum mainnet state; either in realtime or monotonically over some historical block range. Shadow forks bypass gas and contract size restrictions when executing transactions, enabling the emission of detailed event data without incurring gas costs for users on mainnet, and allowing developers to more efficiently utilize the 24,576 byte contract size limit.
 
 Because the changes made on a shadow fork are read-only and the post-transaction state does not change when shadow events are emitted, they can easily stay in sync with mainnet with no risk of halting; assuming the use of either an appropriately set confirmation depth or a mechanism for handling chain reorgs.
 
@@ -44,7 +44,7 @@ Shadow forks execute all transactions in some origin block while only persisting
 
 ## Shadow Contract
 
-A shadow contract is a modified version of a deployed mainnet contract, which is deployed as new bytecode onto a shadow fork using offchain infrastructure. Modifications are made on a shadow contract in order to get additional event data that is not logged on the mainnet contract, or event data that would be otherwise uneconomical to generate on mainnet. Shadow contracts have no effect on their mainnet counterparts, can be updated at any time, and anyone can write a custom implementation permissionlessly.
+A shadow contract is a modified version of a deployed mainnet contract, which is deployed as new bytecode onto a shadow fork using off-chain infrastructure. Modifications are made on a shadow contract in order to get additional event data that is not logged on the mainnet contract, or event data that would be otherwise uneconomical to generate on mainnet. Shadow contracts have no effect on their mainnet counterparts, can be updated at any time, and anyone can write a custom implementation permissionlessly.
 
 ## Shadow Event Emission
 
@@ -176,25 +176,25 @@ We propose introducing a new JSON RPC endpoint (e.g. `shadow_getAddresses`) that
 
 # Rationale
 
-Users have spent >330K ETH on gas fees to emit events. In periods of high activity, this has spiked to ~21K ETH spent on event gas fees in a single month. Because of this, developers increasingly choose to log minimal events to reduce gas costs for their end users. As a result, the majority of data augmentation being done today in complex offchain indexing pipelines.
+Users have spent >330K ETH on gas fees to emit events. In periods of high activity, this has spiked to ~21K ETH spent on event gas fees in a single month. Because of this, developers increasingly choose to log minimal events to reduce gas costs for their end users. As a result, the majority of data augmentation is being done today in complex off-chain indexing pipelines.
 
-The proposed standard for shadow events aims to balance the need for rich onchain data with the constraints of blockchain resource costs. By establishing a standard, we can ensure that shadow events are emitted and accessed in a consistent manner, facilitating broader adoption and integration with existing tools.
+The proposed standard for shadow events aims to balance the need for rich on-chain data with the constraints of blockchain resource costs. By establishing a standard, we can ensure that shadow events are emitted and accessed in a consistent manner, facilitating broader adoption and integration with existing tools.
 
 # Backwards Compatibility
 
-Shadow events are fully backwards compatible as they do not affect the execution or the state of the mainnet contracts. They are an offchain addition that can be adopted incrementally by the community.
+Shadow events are fully backwards compatible as they do not affect the execution or the state of the mainnet contracts. They are an off-chain addition that can be adopted incrementally by the community.
 
 # Security Considerations
 
 ## Centralization
 
-While shadow events do not affect onchain state, care must be taken to ensure that the offchain infrastructure for emitting and accessing shadow events is secure and reliable. Additionally, developers must be thoughtful about the reliance on shadow events, as to not introduce severe centralized trust risks.
+While shadow events do not affect on-chain state, care must be taken to ensure that the off-chain infrastructure for emitting and accessing shadow events is secure and reliable. Additionally, developers must be thoughtful about the reliance on shadow events, as to not introduce severe centralized trust risks.
 
 ## Executional Correctness
 
 Shadow fork implementations should take care to verify executional correctness of transactions. Similar to node clients, shadow execution environments can be open sourced and reviewed by the community.
 
-Different code paths can be reached when re-executing a mainnet transaction on a shadow fork EVM that removes the use of contract size and gas cost restrictions (e.g. a contract that reaches recursive call-depth 10 on the origin chain but reaches the MAX_STACK_LIMIT when ran in a shadow environment). Furthermore, opcodes specific to consensus metadata (e.g. DIFFICULTY) could express different values than that of the mainnet transaction’s execution.
+Different code paths can be reached when re-executing a mainnet transaction on a shadow fork EVM that removes the use of contract size and gas cost restrictions (e.g. a contract that reaches recursive call-depth 10 on the origin chain but reaches the MAX_STACK_LIMIT when run in a shadow environment). Furthermore, opcodes specific to consensus metadata (e.g. DIFFICULTY) could express different values than that of the mainnet transaction’s execution.
 
 Strict verifications should be instilled into shadow execution environments to ensure that re-executed transactions don’t traverse code paths that largely differ from their mainnet counterparts.
 
@@ -202,7 +202,7 @@ Strict verifications should be instilled into shadow execution environments to e
 
 The term "shadow fork” has been used in the past to refer to update shadow forks. This ERC refers to a second type of shadow fork – an application shadow fork:
 
-- **Application shadow forks** - Environment for altering data availability (receipt logs) via an offchain execution environment that allows for the execution of arbitrary EVM bytecode. These are critical for reducing user data footprints while also minimizing transaction gas costs.
+- **Application shadow forks** - Environment for altering data availability (receipt logs) via an off-chain execution environment that allows for the execution of arbitrary EVM bytecode. These are critical for reducing user data footprints while also minimizing transaction gas costs.
 
 - **Upgrade shadow forks** - Environment for testing backwards incompatible node upgrades via a mirrored read-only node environment. These are critical for ensuring that protocol upgrades don’t introduce liveness failures or security vulnerabilities and can demonstrate correctness in a pseudo-production environment.
 


### PR DESCRIPTION
While 'onchain' and 'offchain' are often used informally, the hyphenated versions, 'on-chain' and 'off-chain', are more commonly seen in technical documentation and blockchain literature. This change aims to align codebase with general industry standards for terminology, ensuring consistency and improving readability.